### PR TITLE
Allow Renovate PRs to commit terraform-docs changes

### DIFF
--- a/.github/workflows/continuous-integration-terraform.yml
+++ b/.github/workflows/continuous-integration-terraform.yml
@@ -5,13 +5,16 @@ on:
     branches: main
   pull_request:
 
+env:
+  GITHUB_PR_BRANCH: ""
+
 jobs:
   terraform-validate:
     name: Terraform Validate
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get terraform version
         id: get-terraform-version
@@ -56,15 +59,38 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.TERRAFORM_DOCS_RENOVATE_WORKFLOW_GITHUB_TOKEN }}
+
+      - name: Get PR base branch
+        id: pr-base-branch-name
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "GITHUB_PR_BRANCH=${{ github.head_ref }}" >> $GITHUB_ENV
+
+      - name: Output PR base branch
+        run: |
+          echo "$GITHUB_PR_BRANCH"
 
       - name: Generate Terraform docs
         uses: terraform-docs/gh-actions@v1.0.0
+        if: "!startsWith(env.GITHUB_PR_BRANCH, 'renovate/')"
         with:
           working-dir: .
           config-file: .terraform-docs.yml
           output-file: README.md
           output-method: inject
           fail-on-diff: true
+
+      - name: Generate Terraform docs for Renovate
+        uses: terraform-docs/gh-actions@v1.0.0
+        if: "startsWith(env.GITHUB_PR_BRANCH, 'renovate/')"
+        with:
+          working-dir: .
+          config-file: .terraform-docs.yml
+          output-file: README.md
+          output-method: inject
+          git-push: true
+          ref: ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
* When Renovate opens a PR to update Terraform dependencies, the terraform-docs check can fail, if the documentation needs updating to reflect the new dependency version.
* This checks the branch name, and runs the terraform-docs action with `git-push` set to true.
* A github token is required, set as a secret (`TERRAFORM_DOCS_RENOVATE_WORKFLOW_GITHUB_TOKEN`) so that the checks are ran again after it pushes it's commit. It won't end up in an endless loop, because terraform-docs won't need to make another commit when there aren't any changes.